### PR TITLE
Upgrade Node to 4.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "nodeunit-httpclient": "0.2.x"
   },
   "engines": {
-    "node": "0.10.x",
+    "node": "4.2.2",
     "npm": "1.2.x"
   }
 }


### PR DESCRIPTION
One line change. Should work, because Heroku supports the new version:

https://devcenter.heroku.com/articles/nodejs-support#node-js-runtimes