### PR TITLE
Enable seeing more error information

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -102,7 +102,8 @@ var conf = convict({
     logging: {
         doc: 'Options given as a parameter to logger (https://github.com/baryon/tracer).',
         format: Object,
-        default: undefined
+        default: undefined,
+        env: 'LOGGING_OPTIONS'
     },
     locMapConfig: {
         locationNotificationTimeout: {

--- a/locmap/test/testRESTAPI_locmap.js
+++ b/locmap/test/testRESTAPI_locmap.js
@@ -749,7 +749,6 @@ tests.both.userRenameContacts = function(version) {
 
             lmHelpers.api.post(test, '/' + version + '/user/' + reply.id + '/rename/' + 'testUserId',
                 auth, function () {
-                    console.log('got rename result');
                     lmHelpers.api.get(test, '/' + version + '/user/' + reply.id + '/contacts', auth,
                         function (res) {
                             var expected = {canseeme: [], icansee: [], ignored: [], idmapping: []};

--- a/lokki-server.js
+++ b/lokki-server.js
@@ -56,6 +56,25 @@ app.use('/api', function (req, res, next) {
     return next();
 });
 
+// see more information when route code throws an error
+app.use(function (req, res, next) {
+    // create per request domain instance
+    var domain = require('domain');
+    var d = domain.create();
+
+    d.on('error', function (err) {
+        logger.error(err);
+        logger.error(err.stack);
+        throw err;
+    });
+
+    d.run(function() {
+        process.domain.add(req);
+        process.domain.add(res);
+        next();
+    });
+});
+
 if (conf.get('neverCrash')) {
     // do not allow production server to crash
     process.on('uncaughtException', function (err) {

--- a/test_helpers/test_helpers.js
+++ b/test_helpers/test_helpers.js
@@ -188,7 +188,7 @@ module.exports = {
         testServerProcess.stdout.on('data', function(data) {
             var str = data.toString();
             var lines = str.split(/(\r?\n)/g);
-            logger.trace('Server log: %s', lines.join('').trim());
+            logger.debug('Server log: %s', lines.join('').trim());
         });
 
         // Poll server until able to connect


### PR DESCRIPTION
Can now see server output while running tests by running tests with:

    LOGGING_OPTIONS='{"level":"debug"}' node unittest-runner.js